### PR TITLE
Fix for wrong BonusId and DifficultyId

### DIFF
--- a/Frames/Manager.lua
+++ b/Frames/Manager.lua
@@ -482,8 +482,19 @@ function Manager:PopulateSlots(slotContainer)
     local label = itemGroup:GetUserData("label")
     local itemid = BiSList[slotId] and BiSList[slotId].item
     local isLegionWeapon = false
-    if (slotId == 16 or slotId == 17) and (self:GetSelected(self.RAIDTIER) >= 70000 and self:GetSelected(self.RAIDTIER) < 80000) then
-      --Artifact weapons
+    ---------------------- Artifact Neck ------------------------------------
+    if slotId == 2 and self:GetSelected(self.RAIDTIER) >= 80000 and self:GetSelected(self.RAIDTIER) < 90000 then
+      icon:SetUserData("disabled", true)
+      button:SetDisabled(true)
+      NeckItemId = 158075
+      local _, link, _, _, _, _, _, _, _, texture = GetItemInfo(NeckItemId)
+      icon:SetImage(texture)
+      icon:SetUserData("itemid", NeckItemId)
+      icon:SetUserData("itemlink", link)
+      label:SetText(link)
+      isLegionWeapon = true
+    ---------------------- Artifact Weapons ------------------------------------
+    elseif (slotId == 16 or slotId == 17) and (self:GetSelected(self.RAIDTIER) >= 70000 and self:GetSelected(self.RAIDTIER) < 80000) then
       icon:SetUserData("disabled", true)
       button:SetDisabled(true)
       local artifactInfo = select(slotId == 16 and 1 or 2, self.Artifacts:ForSpecialization(specialization))

--- a/Modules/BfaDungeons/BestInSlotRedux_BfaDungeons.lua
+++ b/Modules/BfaDungeons/BestInSlotRedux_BfaDungeons.lua
@@ -2,9 +2,9 @@ local Dungeons = LibStub("AceAddon-3.0"):GetAddon("BestInSlotRedux"):NewModule("
 local dungeonTierId = 80003
 local bonusIds = {
   bonusids = {
-    [1] = {4777, 1482, 4785},
-    [2] = {4778, 1497, 4785},
-    [3] = {4779, 1512, 4786}
+    [1] = {3524},
+    [2] = {3524},
+    [3] = {3524}
   },
   difficultyconversion = {
     [1] = 1, --Raid Normal

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -8,14 +8,14 @@ function Uldir:OnEnable()
   self:RegisterRaidTier("Battle for Azeroth", 80000, uldirName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
   self:RegisterRaidInstance(80000, UD, uldirName, {
     bonusids = {
-      [1] = {4798, 1477},
-      [2] = {4799, 1492},
-      [3] = {4800, 1507},
+      [1] = {3524},
+      [2] = {3524},
+      [3] = {3524}
     },
     difficultyconversion = {
-      [1] = 14, --Raid Normal
-      [2] = 15, --Raid Heroic
-      [3] = 16, --Raid Mythic
+      [1] = 3, --Raid Normal
+      [2] = 5, --Raid Heroic
+      [3] = 6, --Raid Mythic
     }
   })
   --------------------------------------------------


### PR DESCRIPTION
This should fix wrong item tooltip, throwing an error with AzeriteTooltip addon, as it can't retrieve Azerite powers with these bonusId/difficultyId.

You should just change any BonusID function so ``numBonusId = 1`` and ``bonusId1 = 3524``, and only change ``instanceDifficultyID`` like the Encounter Journal does. BonusIDs are used mainly for item procs and it's useless to mess with them for this addon purposes.