### PR TITLE
Wrong NPCIDs, Missing Alliance Boss, World Boss Loot

### DIFF
--- a/Frames/CustomItems.lua
+++ b/Frames/CustomItems.lua
@@ -8,7 +8,7 @@ local BestInSlot, L, AceGUI = unpack(select(2, ...))
 local CustomItems = BestInSlot:GetMenuPrototype(L["Custom Items"])
 CustomItems.Width = 500
 CustomItems.Height = 400
-local minimumIlvl = 550
+local minimumIlvl = 300
 local failtimer
 local upgradeStages = {
   [525] = "Stage 1", 
@@ -135,7 +135,7 @@ function CustomItems:IsItemAllowed(itemid)
       tinsert(errors, ("- "..L["This item already exists in the database! It is registered to %s"]):format(self:GetDescription(self.RAIDTIER, raidtier)))
     end
   end
-  if iLevel < 500 then
+  if iLevel < minimumIlvl then
     tinsert(errors, "- "..(L["The minimum item level of custom items is %d!"]):format(minimumIlvl))
   end
   if #errors > 0 then

--- a/Frames/Manager.lua
+++ b/Frames/Manager.lua
@@ -482,8 +482,20 @@ function Manager:PopulateSlots(slotContainer)
     local label = itemGroup:GetUserData("label")
     local itemid = BiSList[slotId] and BiSList[slotId].item
     local isLegionWeapon = false
-    if (slotId == 16 or slotId == 17) and (self:GetSelected(self.RAIDTIER) >= 70000 and self:GetSelected(self.RAIDTIER) < 80000) then
-      --Artifact weapons
+----------------------Artifact Neck------------------------------------
+	if slotId == 2 and self:GetSelected(self.RAIDTIER) >= 80000 and self:GetSelected(self.RAIDTIER) < 90000 then
+    button:SetText(nil)
+		icon:SetUserData("disabled", true)
+		button:SetDisabled(true)
+			NeckItemId = 158075
+				local _, link, _, _, _, _, _, _, _, texture, _ = GetItemInfo(NeckItemId)
+				icon:SetImage(texture)
+				icon:SetUserData("itemid", NeckItemId)
+				icon:SetUserData("itemlink", link)
+				label:SetText(link)
+				isLegionWeapon = true
+    elseif (slotId == 16 or slotId == 17) and (self:GetSelected(self.RAIDTIER) >= 70000 and self:GetSelected(self.RAIDTIER) < 79999) then
+----------------------Artifact weapons------------------------------------
       icon:SetUserData("disabled", true)
       button:SetDisabled(true)
       local artifactInfo = select(slotId == 16 and 1 or 2, self.Artifacts:ForSpecialization(specialization))

--- a/Frames/Manager.lua
+++ b/Frames/Manager.lua
@@ -488,7 +488,7 @@ function Manager:PopulateSlots(slotContainer)
 		icon:SetUserData("disabled", true)
 		button:SetDisabled(true)
 			NeckItemId = 158075
-				local _, link, _, _, _, _, _, _, _, texture, _ = GetItemInfo(NeckItemId)
+				local _, link, _, _, _, _, _, _, _, texture = GetItemInfo(NeckItemId)
 				icon:SetImage(texture)
 				icon:SetUserData("itemid", NeckItemId)
 				icon:SetUserData("itemlink", link)

--- a/Modules/BfaDungeons/BestInSlotRedux_BfaDungeons.lua
+++ b/Modules/BfaDungeons/BestInSlotRedux_BfaDungeons.lua
@@ -2,9 +2,9 @@ local Dungeons = LibStub("AceAddon-3.0"):GetAddon("BestInSlotRedux"):NewModule("
 local dungeonTierId = 80003
 local bonusIds = {
   bonusids = {
-    [1] = {4777, 1482, 4785},
-    [2] = {4778, 1497, 4785},
-    [3] = {4779, 1512, 4786}
+    [1] = {3524},
+    [2] = {3524},
+    [3] = {3524}
   },
   difficultyconversion = {
     [1] = 1, --Raid Normal
@@ -332,10 +332,25 @@ function Dungeons:SiegeOfBoralus()
   --------------------------------------------------
   ----- Siege of Boralus
   --------------------------------------------------
-  
-
+if UnitFactionGroup("player") == "Alliance" then
   -----------------------------------
-  ----- Sergeant Bainbridge
+  ----- Chopper Redhook (Alliance)
+  -----------------------------------
+  local bossName = EJ_GetEncounterInfo(2132)
+  local lootTable = {
+	159972, --Mutineer's Fate 
+	159973, --Boarder's Billy Club 
+	159968, --Gloves of the Iron Reavers 
+	159965, --Redhook's Cummerbund 
+	159427, --Legplates of the Irontide Raider 
+	159969, --Powdershot Leggings 
+	159251, --Top-Sail Footwraps 
+	162541, --Band of the Roving Scalawag
+  }  
+  self:RegisterBossLoot(siegeofboralus, lootTable, bossName)  
+else
+  -----------------------------------
+  ----- Sergeant Bainbridge (Horde)
   -----------------------------------
   local bossName = EJ_GetEncounterInfo(2133)
   local lootTable = {
@@ -349,7 +364,7 @@ function Dungeons:SiegeOfBoralus()
     162542, --Seal of the City Watch
   }
   self:RegisterBossLoot(siegeofboralus, lootTable, bossName)
-  
+end
 
   -----------------------------------
   ----- Dread Captain Lockwood
@@ -827,75 +842,85 @@ end
 
 function Dungeons:InitializeZoneDetect(ZoneDetect)
   local AD = "ataldazar"
-  ZoneDetect:RegisterMapID(934, AD)
-  ZoneDetect:RegisterNPCID(2082, AD, 1)
-  ZoneDetect:RegisterNPCID(2036, AD, 2)
-  ZoneDetect:RegisterNPCID(2083, AD, 3)
-  ZoneDetect:RegisterNPCID(2030, AD, 4)
+  ZoneDetect:RegisterMapID(934, ataldazar)
+  ZoneDetect:RegisterNPCID(122967, ataldazar, 1)
+  ZoneDetect:RegisterNPCID(122965, ataldazar, 2)
+  ZoneDetect:RegisterNPCID(122963, ataldazar, 3)
+  ZoneDetect:RegisterNPCID(122968, ataldazar, 4)
 
   local freehold = "freehold"
   ZoneDetect:RegisterMapID(936, freehold)
-  ZoneDetect:RegisterNPCID(2102, freehold, 1)
-  ZoneDetect:RegisterNPCID(2093, freehold, 2)
-  ZoneDetect:RegisterNPCID(2094, freehold, 3)
-  ZoneDetect:RegisterNPCID(2095, freehold, 4)
+  ZoneDetect:RegisterNPCID(126832, freehold, 1)
+  ZoneDetect:RegisterNPCID(126845, freehold, 2)
+  ZoneDetect:RegisterNPCID(126847, freehold, 2)
+  ZoneDetect:RegisterNPCID(126848, freehold, 2)
+  ZoneDetect:RegisterNPCID(126969, freehold, 3)
+  ZoneDetect:RegisterNPCID(126983, freehold, 4)
 
   local kingsrest = "kingsrest"
   ZoneDetect:RegisterMapID(1004, kingsrest)
-  ZoneDetect:RegisterNPCID(2165, kingsrest, 1)
-  ZoneDetect:RegisterNPCID(2171, kingsrest, 2)
-  ZoneDetect:RegisterNPCID(2170, kingsrest, 3)
-  ZoneDetect:RegisterNPCID(2172, kingsrest, 4)
+  ZoneDetect:RegisterNPCID(135322, kingsrest, 1)
+  ZoneDetect:RegisterNPCID(134993, kingsrest, 2)
+  ZoneDetect:RegisterNPCID(135475, kingsrest, 3)
+  ZoneDetect:RegisterNPCID(135470, kingsrest, 3)
+  ZoneDetect:RegisterNPCID(135472, kingsrest, 3)
+  ZoneDetect:RegisterNPCID(136160, kingsrest, 4)
 
   local shrineofthestorm = "shrineofthestorm"
   ZoneDetect:RegisterMapID(1004, shrineofthestorm)
-  ZoneDetect:RegisterNPCID(2153, shrineofthestorm, 1)
-  ZoneDetect:RegisterNPCID(2154, shrineofthestorm, 2)
-  ZoneDetect:RegisterNPCID(2155, shrineofthestorm, 3)
-  ZoneDetect:RegisterNPCID(2156, shrineofthestorm, 4)
+  ZoneDetect:RegisterNPCID(134056, shrineofthestorm, 1)
+  ZoneDetect:RegisterNPCID(134063, shrineofthestorm, 2)
+  ZoneDetect:RegisterNPCID(134058, shrineofthestorm, 2)
+  ZoneDetect:RegisterNPCID(134060, shrineofthestorm, 3)
+  ZoneDetect:RegisterNPCID(134069, shrineofthestorm, 4)
 
   local siegeofboralus = "siegeofboralus"
   ZoneDetect:RegisterMapID(1162, siegeofboralus)
-  ZoneDetect:RegisterNPCID(2133, siegeofboralus, 1)
-  ZoneDetect:RegisterNPCID(2173, siegeofboralus, 2)
-  ZoneDetect:RegisterNPCID(2134, siegeofboralus, 3)
-  ZoneDetect:RegisterNPCID(2140, siegeofboralus, 4)
+  ZoneDetect:RegisterNPCID(128650, siegeofboralus, 1)--Redhook - Alliance
+  ZoneDetect:RegisterNPCID(130834, siegeofboralus, 1)--Bainbridge - Horde
+  ZoneDetect:RegisterNPCID(129208, siegeofboralus, 2)
+  ZoneDetect:RegisterNPCID(130836, siegeofboralus, 3)
+  ZoneDetect:RegisterNPCID(120553, siegeofboralus, 4)
 
   local templeofsethraliss = "templeofsethraliss"
   ZoneDetect:RegisterMapID(1038, templeofsethraliss)
-  ZoneDetect:RegisterNPCID(2142, templeofsethraliss, 1)
-  ZoneDetect:RegisterNPCID(2143, templeofsethraliss, 2)
-  ZoneDetect:RegisterNPCID(2144, templeofsethraliss, 3)
-  ZoneDetect:RegisterNPCID(2145, templeofsethraliss, 4)
+  ZoneDetect:RegisterNPCID(133379, templeofsethraliss, 1)
+  ZoneDetect:RegisterNPCID(133944, templeofsethraliss, 1)
+  ZoneDetect:RegisterNPCID(133384, templeofsethraliss, 2)
+  ZoneDetect:RegisterNPCID(133389, templeofsethraliss, 3)
+  ZoneDetect:RegisterNPCID(133392, templeofsethraliss, 4)
 
   local motherlode = "motherlode"
   ZoneDetect:RegisterMapID(1010, motherlode)
-  ZoneDetect:RegisterNPCID(2109, motherlode, 1)
-  ZoneDetect:RegisterNPCID(2114, motherlode, 2)
-  ZoneDetect:RegisterNPCID(2115, motherlode, 3)
-  ZoneDetect:RegisterNPCID(2116, motherlode, 4)
+  ZoneDetect:RegisterNPCID(129214, motherlode, 1)
+  ZoneDetect:RegisterNPCID(129227, motherlode, 2)
+  ZoneDetect:RegisterNPCID(129231, motherlode, 3)
+  ZoneDetect:RegisterNPCID(129232, motherlode, 4)
 
   local underrot = "underrot"
   ZoneDetect:RegisterMapID(1041, underrot)
-  ZoneDetect:RegisterNPCID(2157, underrot, 1)
-  ZoneDetect:RegisterNPCID(2131, underrot, 2)
-  ZoneDetect:RegisterNPCID(2130, underrot, 3)
-  ZoneDetect:RegisterNPCID(2158, underrot, 4)
+  ZoneDetect:RegisterNPCID(131318, underrot, 1)
+  ZoneDetect:RegisterNPCID(131817, underrot, 2)
+  ZoneDetect:RegisterNPCID(131383, underrot, 3)
+  ZoneDetect:RegisterNPCID(133007, underrot, 4)
 
   local toldagor = "toldagor"
   ZoneDetect:RegisterMapID(974, toldagor)
-  ZoneDetect:RegisterNPCID(2097, toldagor, 1)
-  ZoneDetect:RegisterNPCID(2098, toldagor, 2)
-  ZoneDetect:RegisterNPCID(2099, toldagor, 3)
-  ZoneDetect:RegisterNPCID(2096, toldagor, 4)
+  ZoneDetect:RegisterNPCID(127479, toldagor, 1)
+  ZoneDetect:RegisterNPCID(127484, toldagor, 2)
+  ZoneDetect:RegisterNPCID(127490, toldagor, 3)
+  ZoneDetect:RegisterNPCID(127503, toldagor, 4)
 
   local waycrestmanor = "waycrestmanor"
   ZoneDetect:RegisterMapID(1015, waycrestmanor)
-  ZoneDetect:RegisterNPCID(2125, waycrestmanor, 1)
-  ZoneDetect:RegisterNPCID(2126, waycrestmanor, 2)
-  ZoneDetect:RegisterNPCID(2127, waycrestmanor, 3)
-  ZoneDetect:RegisterNPCID(2128, waycrestmanor, 4)
-  ZoneDetect:RegisterNPCID(2129, waycrestmanor, 5)
+  ZoneDetect:RegisterNPCID(135358, waycrestmanor, 1)
+  ZoneDetect:RegisterNPCID(135359, waycrestmanor, 1)
+  ZoneDetect:RegisterNPCID(135360, waycrestmanor, 1)
+  ZoneDetect:RegisterNPCID(260551, waycrestmanor, 2)
+  ZoneDetect:RegisterNPCID(131863, waycrestmanor, 3)
+  ZoneDetect:RegisterNPCID(131527, waycrestmanor, 4)
+  ZoneDetect:RegisterNPCID(131545, waycrestmanor, 4)
+  ZoneDetect:RegisterNPCID(131864, waycrestmanor, 5)
 
 end
 

--- a/Modules/BfaDungeons/BestInSlotRedux_BfaDungeons.lua
+++ b/Modules/BfaDungeons/BestInSlotRedux_BfaDungeons.lua
@@ -841,7 +841,7 @@ function Dungeons:WaycrestManor()
 end
 
 function Dungeons:InitializeZoneDetect(ZoneDetect)
-  local AD = "ataldazar"
+  local ataldazar = "ataldazar"
   ZoneDetect:RegisterMapID(934, ataldazar)
   ZoneDetect:RegisterNPCID(122967, ataldazar, 1)
   ZoneDetect:RegisterNPCID(122965, ataldazar, 2)

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -182,6 +182,7 @@ function Uldir:OnEnable()
 end
 
 function Uldir:InitializeZoneDetect(ZoneDetect)
+  ZoneDetect:RegisterMapID(1148, ULD)
   ZoneDetect:RegisterNPCID(137119, ULD, 1) --Taloc
   ZoneDetect:RegisterNPCID(135452, ULD, 2) --Mother
   ZoneDetect:RegisterNPCID(133298, ULD, 3) --Fetid Devourer

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -5,8 +5,8 @@ function Uldir:OnEnable()
   
   local uldirName = C_Map.GetMapInfo(1148).name
   self:RegisterExpansion("Battle for Azeroth", EXPANSION_NAME7)
-  self:RegisterRaidTier("Battle for Azeroth", 80000, uldirName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
-  self:RegisterRaidInstance(80000, UD, uldirName, {
+  self:RegisterRaidTier("Battle for Azeroth", 80004, uldirName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
+  self:RegisterRaidInstance(80004, UD, uldirName, {
     bonusids = {
       [1] = {3524},
       [2] = {3524},

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -182,13 +182,12 @@ function Uldir:OnEnable()
 end
 
 function Uldir:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(1148, UD)
-  ZoneDetect:RegisterNPCID(2168, UD, 1) --Taloc
-  ZoneDetect:RegisterNPCID(2167, UD, 2) --MOTHER
-  ZoneDetect:RegisterNPCID(2146, UD, 3) --Fetid Devourer
-  ZoneDetect:RegisterNPCID(2169, UD, 4) --Zek'voz, Herald of N'zoth
-  ZoneDetect:RegisterNPCID(2166, UD, 5) --Vectis
-  ZoneDetect:RegisterNPCID(2195, UD, 6) --Zul, Reborn
-  ZoneDetect:RegisterNPCID(2194, UD, 7) --Mythrax the Unraveler
-  ZoneDetect:RegisterNPCID(2147, UD, 8) --G'huun
+  ZoneDetect:RegisterNPCID(137119, ULD, 1) --Taloc
+  ZoneDetect:RegisterNPCID(135452, ULD, 2) --Mother
+  ZoneDetect:RegisterNPCID(133298, ULD, 3) --Fetid Devourer
+  ZoneDetect:RegisterNPCID(134445, ULD, 4) --Zek'voc, Herald of N'zoth
+  ZoneDetect:RegisterNPCID(134442, ULD, 5) --Vectis
+  ZoneDetect:RegisterNPCID(138967, ULD, 6) --Zul, Reborn
+  ZoneDetect:RegisterNPCID(134546, ULD, 7) --Mythrax the Unraveler
+  ZoneDetect:RegisterNPCID(132998, ULD, 8) --G'huun
 end

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -337,13 +337,13 @@ end
 end
 --------------------------------------
 function Uldir:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(1148, ULD)
-  ZoneDetect:RegisterNPCID(137119, ULD, 1) --Taloc
-  ZoneDetect:RegisterNPCID(135452, ULD, 2) --Mother
-  ZoneDetect:RegisterNPCID(133298, ULD, 3) --Fetid Devourer
-  ZoneDetect:RegisterNPCID(134445, ULD, 4) --Zek'voc, Herald of N'zoth
-  ZoneDetect:RegisterNPCID(134442, ULD, 5) --Vectis
-  ZoneDetect:RegisterNPCID(138967, ULD, 6) --Zul, Reborn
-  ZoneDetect:RegisterNPCID(134546, ULD, 7) --Mythrax the Unraveler
-  ZoneDetect:RegisterNPCID(132998, ULD, 8) --G'huun
+  ZoneDetect:RegisterMapID(1148, UD)
+  ZoneDetect:RegisterNPCID(137119, UD, 1) --Taloc
+  ZoneDetect:RegisterNPCID(135452, UD, 2) --Mother
+  ZoneDetect:RegisterNPCID(133298, UD, 3) --Fetid Devourer
+  ZoneDetect:RegisterNPCID(134445, UD, 4) --Zek'voc, Herald of N'zoth
+  ZoneDetect:RegisterNPCID(134442, UD, 5) --Vectis
+  ZoneDetect:RegisterNPCID(138967, UD, 6) --Zul, Reborn
+  ZoneDetect:RegisterNPCID(134546, UD, 7) --Mythrax the Unraveler
+  ZoneDetect:RegisterNPCID(132998, UD, 8) --G'huun
 end

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -179,7 +179,7 @@ function Uldir:OnEnable()
     160654, --Vanquished Tendril of G'huun
   }
   self:RegisterBossLoot(UD, lootTable, bossName)
-end
+	
   --------------------------------------------------
   ----- World Boss
   --------------------------------------------------

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -180,7 +180,162 @@ function Uldir:OnEnable()
   }
   self:RegisterBossLoot(UD, lootTable, bossName)
 end
-
+  --------------------------------------------------
+  ----- World Boss
+  --------------------------------------------------
+  local worldDropDifficulty = {1,2,3}
+  local misc = {
+    -----------------------------------
+    ----- T'zane
+    -----------------------------------
+    [EJ_GetEncounterInfo(2139)] = {
+		161396, --Petrified Mask of the Afterlife 
+		161391, --Deathshambler's Shoulderpads 
+		161392, --Bindings of Eternal Fears 
+		161397, --Soulplank Vambraces 
+		161389, --Cinch of All-Consuming Death 
+		164383, --Death Devouring Girdle 
+		161393, --Legguards of the Barkbound Dead 
+		161387, --Wailing Terror Leggings 
+		161395, --Swampwalker's Soul-Treads 
+		161412, --Spiritbound Voodoo Burl 
+		161411, --T'zane's Barkspines
+	difficulty = worldDropDifficulty
+    },
+    -----------------------------------
+    ----- Ji'arak
+    -----------------------------------
+    [EJ_GetEncounterInfo(2141)] = {
+		161401, --Matriarch's Shadowveil 
+		164384, --Windswept Dinorider's Cape 
+		161409, --Stormcrash Chestguard 
+		161388, --Gloves of Enveloping Winds 
+		161403, --Avian Clutch Belt 
+		161394, --Hurricane Cinch 
+		161390, --Savage Terrorwing Leggings 
+		161407, --Windshear Leggings 
+		161371, --Galebreaker's Sabatons
+	difficulty = worldDropDifficulty
+    },
+    -----------------------------------
+    ----- Hailstone Construct
+    -----------------------------------
+    [EJ_GetEncounterInfo(2197)] = {
+		161372, --Ice-Carved Shoulderplates 
+		161367, --Hailstone Hauberk 
+		161364, --Chill's End Wristguards 
+		161370, --Glacial Spike Gauntlets 
+		161368, --Freezing Tempest Waistguard 
+		164386, --Girdle of Biting Winds 
+		161362, --Frostbreath Leggings 
+		161366, --Ice Stalker Boots 
+		161361, --Ice-Rimed Slippers 
+		161380, --Drust-Runed Icicle 
+		161381, --Permafrost-Encrusted Heart
+	difficulty = worldDropDifficulty
+    },
+    -----------------------------------
+    ----- Azurethos, The Winged Typhoon
+    -----------------------------------
+    [EJ_GetEncounterInfo(2199)] = {
+		161356, --Feathered Galeforce Crest 
+		161352, --Chestguard of Dire Winds 
+		161369, --Bindings of the Winged Typhoon 
+		161398, --Talonscored Azure Vambraces 
+		161350, --Windcaller's Down Handwraps 
+		161360, --Roost-Defender's Legguards 
+		161365, --Footpads of the Encircling Storm 
+		161363, --Sandals of Rustling Rage 
+		161377, --Azurethos' Singed Plumage 
+		161379, --Galecaller's Beak 
+		161378, --Plume of the Seaborne Avian
+	difficulty = worldDropDifficulty
+    },
+    -----------------------------------
+    ----- Warbringer Yenajz
+    -----------------------------------
+    [EJ_GetEncounterInfo(2198)] = {
+		161349, --Amice of the Rending Abyss 
+		161357, --Spaulders of the Enveloping Maw 
+		161351, --Wristwraps of Warped Reality 
+		161358, --Existence-Shattering Gauntlets 
+		161353, --Shadow-Wreathed Gloves 
+		161354, --Leggings of the Endless Void 
+		161355, --Yenajz's Chitinous Stompers 
+		161359, --Band of Intense Gravitation 
+		161376, --Prism of Dark Intensity
+    difficulty = worldDropDifficulty
+    },
+    -----------------------------------
+    ----- Dunegorger Kraulok
+    -----------------------------------
+    [EJ_GetEncounterInfo(2210)] = {
+		161404, --Hood of the Sinuous Devilsaur 
+		164385, --Desert Nomad's Wrap 
+		161400, --Raider's Shrouding Thobe 
+		161406, --Shrouded Sandscale Bracers 
+		161405, --Dunegorger's Grips 
+		161402, --Gloves of the Desert Assassin 
+		161399, --Cord of Flowing Sands 
+		161408, --Sandswept Legionnaire's Legplates 
+		161419, --Kraulok's Claw
+     difficulty = worldDropDifficulty
+   },
+  } 
+ ------------------------Alliance------------------------------------------------  
+	local misc_alliance = { 
+		-----------------------------------
+		----- Doom's Howl (Alliance)
+		-----------------------------------
+		[EJ_GetEncounterInfo(2213)] = {
+			161464, --Alliance Bowman's Coif 
+			161466, --Battlemage's Collar 
+			161468, --Gilded-Wing Shoulderguards 
+			161471, --Lion's Roar Pauldrons 
+			161465, --Warcaster's Arcane Mantle 
+			161470, --Polished Shieldbearer's Breastplate 
+			161469, --Sharpshooter's Chainmail Hauberk 
+			161467, --Vest of the Veiled Gryphon 
+			161472, --Lion's Grace 
+			161473, --Lion's Guile 
+			161474, --Lion's Strength
+		difficulty = worldDropDifficulty
+		},
+	}
+------------------------Horde------------------------------------------------  
+	local misc_horde = {
+		-----------------------------------
+		----- The Lion's Roar (Horde)
+		-----------------------------------
+		[EJ_GetEncounterInfo(2212)] = {
+			161455, --Battlemage's Collar 
+			161453, --Warscout's Horned Helm 
+			161457, --Dire-Tooth Spaulders 
+			161460, --Spiked Dreadshield Pauldrons 
+			161454, --Warcaster's Doom Mantle 
+			161456, --Doom's Howl Vest 
+			161459, --Molded War Machine Grill 
+			161458, --Scalemail Battle Harness 
+			161463, --Doom's Fury 
+			161461, --Doom's Hatred 
+			161462, --Doom's Wake
+		difficulty = worldDropDifficulty
+		},
+	}
+-------- World Boss Tables Merge -----------
+	function WorldBossMerge(t1, t2)
+	   for k,v in pairs(t2) do
+		  t1 [k] = v
+	   end 
+	   return t1
+	end
+	if UnitFactionGroup("player") == "Alliance" then
+		self:RegisterMiscItems(UD, WorldBossMerge(misc, misc_alliance))
+	else
+		self:RegisterMiscItems(UD, WorldBossMerge(misc, misc_horde))
+	end
+end
+--------------------------------------
 function Uldir:InitializeZoneDetect(ZoneDetect)
   ZoneDetect:RegisterMapID(1148, ULD)
   ZoneDetect:RegisterNPCID(137119, ULD, 1) --Taloc

--- a/Modules/BfaRaids/Uldir.lua
+++ b/Modules/BfaRaids/Uldir.lua
@@ -8,14 +8,14 @@ function Uldir:OnEnable()
   self:RegisterRaidTier("Battle for Azeroth", 80000, uldirName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
   self:RegisterRaidInstance(80000, UD, uldirName, {
     bonusids = {
-      [1] = {4798, 1477},
-      [2] = {4799, 1492},
-      [3] = {4800, 1507},
+      [1] = {3524},
+      [2] = {3524},
+      [3] = {4800}
     },
     difficultyconversion = {
-      [1] = 14, --Raid Normal
-      [2] = 15, --Raid Heroic
-      [3] = 16, --Raid Mythic
+      [1] = 3, --Raid Normal
+      [2] = 5, --Raid Heroic
+      [3] = 6, --Raid Mythic
     }
   })
   --------------------------------------------------

--- a/Modules/LegionDungeon/BestInSlotRedux_LegionDungeons.lua
+++ b/Modules/LegionDungeon/BestInSlotRedux_LegionDungeons.lua
@@ -10,7 +10,7 @@ local bonusIds = {
 
 function Dungeons:VioletHold()
   local VH = "VH"
-  local name = GetMapNameByID(1066)
+  local name = C_Map.GetMapInfo(732).name
   self:RegisterRaidInstance(dungeonTierId, VH, name, bonusIds)
   --------------------------------------------------
   ----- Assault on Violet Hold
@@ -188,7 +188,7 @@ end
 
 function Dungeons:BlackRookHold()
   local BRH = "BRH"
-  local name = GetMapNameByID(1081)
+  local name = C_Map.GetMapInfo(751).name
   self:RegisterRaidInstance(dungeonTierId, BRH, name, bonusIds)
   --------------------------------------------------
   ----- Black Rook Hold
@@ -286,7 +286,7 @@ end
 
 function Dungeons:CourtOfStars()
   local CoS = "CoS"
-  local name = GetMapNameByID(1087)
+  local name = C_Map.GetMapInfo(761).name
   self:RegisterRaidInstance(dungeonTierId, CoS, name, bonusIds)
   --------------------------------------------------
   ----- Court of Stars
@@ -365,7 +365,7 @@ end
 
 function Dungeons:DarkheartThicket()
   local DT = "DT"
-  local name = GetMapNameByID(1067)
+  local name = C_Map.GetMapInfo(733).name
   self:RegisterRaidInstance(dungeonTierId, DT, name, bonusIds)
   --------------------------------------------------
   ----- Darkheart Thicket
@@ -465,7 +465,7 @@ end
 
 function Dungeons:EyeOfAzshara()
   local EoA = "EoA"
-  local name = GetMapNameByID(1046)
+  local name = C_Map.GetMapInfo(713).name
   self:RegisterRaidInstance(dungeonTierId, EoA, name, bonusIds)
   --------------------------------------------------
   ----- Eye of Azshara
@@ -576,7 +576,7 @@ end
 
 function Dungeons:HallsOfValor()
   local HoV = "HoV"
-  local name = GetMapNameByID(1041)
+  local name = C_Map.GetMapInfo(703).name
   self:RegisterRaidInstance(dungeonTierId, HoV, name, bonusIds)
   --------------------------------------------------
   ----- Halls of Valor
@@ -690,7 +690,7 @@ end
 
 function Dungeons:MawOfSouls()
   local MoS = "MoS"
-  local name = GetMapNameByID(1042)
+  local name = C_Map.GetMapInfo(706).name
   self:RegisterRaidInstance(dungeonTierId, MoS, name, bonusIds)
   --------------------------------------------------
   ----- Maw of Souls
@@ -767,7 +767,7 @@ end
 
 function Dungeons:NeltharionsLair()
   local NL = "NL"
-  local name = GetMapNameByID(1065)
+  local name = C_Map.GetMapInfo(731).name
   self:RegisterRaidInstance(dungeonTierId, NL, name, bonusIds)
   --------------------------------------------------
   ----- Neltharion's Lair
@@ -861,7 +861,7 @@ end
 
 function Dungeons:Arcway()
   local Arc = "Arc"
-  local name = GetMapNameByID(1079)
+  local name = C_Map.GetMapInfo(749).name
   self:RegisterRaidInstance(dungeonTierId, Arc, name, bonusIds)
   --------------------------------------------------
   ----- The Arcway
@@ -972,7 +972,7 @@ end
 
 function Dungeons:VaultOfTheWardens()
   local VotW = "VotW"
-  local name = GetMapNameByID(1045)
+  local name = C_Map.GetMapInfo(677).name
   self:RegisterRaidInstance(dungeonTierId, VotW, name, bonusIds)
   --------------------------------------------------
   ----- Vault of the Wardens
@@ -1082,9 +1082,9 @@ end
 
 function Dungeons:ReturnToKarazhan()
   local RtK = "RtK"
-  --local name1 = GetMapNameByID(1651) -- Lower
-  --local name2 = GetMapNameByID(1651) -- Upper
-  local name3 = GetMapNameByID(1115) -- Normal / Old (need real ID -.- )
+  --local name1 = C_Map.GetMapInfo(1651).name -- Lower
+  --local name2 = C_Map.GetMapInfo(1651).name -- Upper
+  local name3 = C_Map.GetMapInfo(809).name -- Normal / Old (need real ID -.- )
   self:RegisterRaidInstance(dungeonTierId, RtK, name3, bonusIds)
   --------------------------------------------------
   ----- Return to Karazhan
@@ -1287,7 +1287,7 @@ end
 
 function Dungeons:CathedralOfEternalNight()
   local CoEN = "CoEN"
-  local name = GetMapNameByID(1146)
+  local name = C_Map.GetMapInfo(845).name
   self:RegisterRaidInstance(dungeonTierId, CoEN, name, bonusIds)
   --------------------------------------------------
   ----- Cathedral of Eternal Night
@@ -1378,7 +1378,7 @@ end
 
 function Dungeons:SeatOfTheTriumvirate()
   local SotT = "SotT"
-  local name = GetMapNameByID(1178)
+  local name = C_Map.GetMapInfo(903).name
   self:RegisterRaidInstance(dungeonTierId, SotT, name, bonusIds)
   --------------------------------------------------
   ----- Seat of the Triumvirate

--- a/Modules/LegionModule/AntorusTheBurningThrone.lua
+++ b/Modules/LegionModule/AntorusTheBurningThrone.lua
@@ -4,7 +4,7 @@ function AntorusTheBurningThrone:OnEnable()
   local L = LibStub("AceLocale-3.0"):GetLocale("BestInSlotRedux")
 
   local tierHelm, tierShoulders, tierChest, tierLegs, tierGloves, tierCloak = 1, 3, 5, 7, 10, 15
-  local antorusTheBurningThroneName = GetMapNameByID(1188)
+  local antorusTheBurningThroneName = C_Map.GetMapInfo(909).name
   self:RegisterExpansion("Legion", EXPANSION_NAME6)
   self:RegisterRaidTier("Legion", 70300, antorusTheBurningThroneName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6, PLAYER_DIFFICULTY3)
   self:RegisterRaidInstance(70300, AtBT, antorusTheBurningThroneName,  {
@@ -516,7 +516,7 @@ function AntorusTheBurningThrone:OnEnable()
 end
 
 function AntorusTheBurningThrone:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(1188, AtBT)
+  ZoneDetect:RegisterMapID(909, AtBT)
   -- Multiple boss ID's for some reason on most bosses
   ZoneDetect:RegisterNPCID(122450, AtBT, 1) --Garothi Worldbreaker
   ZoneDetect:RegisterNPCID(123371, AtBT, 1) --Garothi Worldbreaker

--- a/Modules/LegionModule/EmeraldNightmare.lua
+++ b/Modules/LegionModule/EmeraldNightmare.lua
@@ -3,7 +3,7 @@ local EN = "EN"
 function EmeraldNightmare:OnEnable()
   local L = LibStub("AceLocale-3.0"):GetLocale("BestInSlotRedux")
   
-  local emeraldNightmareName = GetMapNameByID(1094)
+  local emeraldNightmareName = C_Map.GetMapInfo(777).name
   self:RegisterExpansion("Legion", EXPANSION_NAME6)
   self:RegisterRaidTier("Legion", 70010, emeraldNightmareName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
   self:RegisterRaidInstance(70010, EN, emeraldNightmareName, {
@@ -346,7 +346,7 @@ function EmeraldNightmare:OnEnable()
 end
 
 function EmeraldNightmare:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(1094, EN)
+  ZoneDetect:RegisterMapID(777, EN)
   
   ZoneDetect:RegisterNPCID(102672, EN, 1) --Nythendra
   ZoneDetect:RegisterNPCID(105393, EN, 2) --Il'gynoth

--- a/Modules/LegionModule/Nighthold.lua
+++ b/Modules/LegionModule/Nighthold.lua
@@ -3,7 +3,7 @@ local NH = "NH"
 function Nighthold:OnEnable()
   local L = LibStub("AceLocale-3.0"):GetLocale("BestInSlotRedux")
   
-  local nightHoldName = GetMapNameByID(1088)
+  local nightHoldName = C_Map.GetMapInfo(764).name
   self:RegisterExpansion("Legion", EXPANSION_NAME6)
   self:RegisterRaidTier("Legion", 70011, nightHoldName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
   self:RegisterRaidInstance(70011, NH, nightHoldName, {
@@ -331,7 +331,7 @@ function Nighthold:OnEnable()
 end
 
 function Nighthold:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(1088, NH)
+  ZoneDetect:RegisterMapID(764, NH)
   
   ZoneDetect:RegisterNPCID(102263, NH, 1) --Skorpyron
   ZoneDetect:RegisterNPCID(104415, NH, 2) --Chronomatic Anomaly

--- a/Modules/LegionModule/TombOfSargeras.lua
+++ b/Modules/LegionModule/TombOfSargeras.lua
@@ -3,7 +3,7 @@ local ToS = "ToS"
 function TombOfSargeras:OnEnable()
   local L = LibStub("AceLocale-3.0"):GetLocale("BestInSlotRedux")
 
-  local tombOfSargerasName = C_Map.GetMapInfo(806).name
+  local tombOfSargerasName = C_Map.GetMapInfo(850).name
   self:RegisterExpansion("Legion", EXPANSION_NAME6)
   self:RegisterRaidTier("Legion", 70200, tombOfSargerasName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
   self:RegisterRaidInstance(70200, ToS, tombOfSargerasName,  {
@@ -330,7 +330,7 @@ function TombOfSargeras:OnEnable()
 --  end
 end
 function TombOfSargeras:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(806, ToS)
+  ZoneDetect:RegisterMapID(850, ToS)
   ZoneDetect:RegisterNPCID(115844, ToS, 1) --Goroth
   
   ZoneDetect:RegisterNPCID(116691, ToS, 2) --Demonic Inquisition (Belac)

--- a/Modules/LegionModule/TombOfSargeras.lua
+++ b/Modules/LegionModule/TombOfSargeras.lua
@@ -3,7 +3,7 @@ local ToS = "ToS"
 function TombOfSargeras:OnEnable()
   local L = LibStub("AceLocale-3.0"):GetLocale("BestInSlotRedux")
 
-  local tombOfSargerasName = GetMapNameByID(1147)
+  local tombOfSargerasName = C_Map.GetMapInfo(806).name
   self:RegisterExpansion("Legion", EXPANSION_NAME6)
   self:RegisterRaidTier("Legion", 70200, tombOfSargerasName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
   self:RegisterRaidInstance(70200, ToS, tombOfSargerasName,  {
@@ -330,7 +330,7 @@ function TombOfSargeras:OnEnable()
 --  end
 end
 function TombOfSargeras:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(1147, ToS)
+  ZoneDetect:RegisterMapID(806, ToS)
   ZoneDetect:RegisterNPCID(115844, ToS, 1) --Goroth
   
   ZoneDetect:RegisterNPCID(116691, ToS, 2) --Demonic Inquisition (Belac)

--- a/Modules/LegionModule/TrialOfValor.lua
+++ b/Modules/LegionModule/TrialOfValor.lua
@@ -3,7 +3,7 @@ local ToV = "ToV"
 function TrialOfValor:OnEnable()
     local L = LibStub("AceLocale-3.0"):GetLocale("BestInSlotRedux")
   
-  local trialOfValorName = GetMapNameByID(1114)
+  local trialOfValorName = C_Map.GetMapInfo(806).name
   self:RegisterExpansion("Legion", EXPANSION_NAME6)
   self:RegisterRaidTier("Legion", 70005, trialOfValorName, PLAYER_DIFFICULTY1, PLAYER_DIFFICULTY2, PLAYER_DIFFICULTY6)
   self:RegisterRaidInstance(70005, ToV, trialOfValorName, {
@@ -95,7 +95,7 @@ function TrialOfValor:OnEnable()
 end
 
 function TrialOfValor:InitializeZoneDetect(ZoneDetect)
-  ZoneDetect:RegisterMapID(1114, ToV)
+  ZoneDetect:RegisterMapID(806, ToV)
   
   ZoneDetect:RegisterNPCID(114263, ToV, 1) --Odyn
   ZoneDetect:RegisterNPCID(114344, ToV, 2) --Guarm

--- a/Modules/ZoneDetection.lua
+++ b/Modules/ZoneDetection.lua
@@ -50,6 +50,7 @@ local difficultyTable = {
   [15] = 2,
   [16] = 3,
   [17] = 4,
+  [23] = 3, -- BfA Mythic Dungeon
 }
 
 function ZoneDetect:GetDifficulty()


### PR DESCRIPTION
Uldir.lua
Fix the Wrong NPCIDs
Added World Boss Loot to Uldir
Raid Tier Version changed to higher than Dungeons, as the BiS window always jumps to the highest version when loading an expansion.

BestInSlotRedux_BfaDungeons.lua:
Added Missing Alliance Boss in Siege of Boralus

ZoneDetection:
Added BfA Mythic Dungeon difficulty for Boss Tooltips

Manager.lua:
Added Heart of Azeroth

BestInSlotRedux_LegionDungeons.lua / All Legion Raids.lua
Fix MAP for BfA

CustomItems.lua
Fix minimumIlvl for BfA
